### PR TITLE
This commenting was accidental I think it should be reverted

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2923,8 +2923,8 @@ static void transfer_destroy(struct xdma_dev *xdev, struct xdma_transfer *xfer)
 		struct sg_table *sgt = xfer->sgt;
 
 		if (sgt->nents) {
-/*			pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents,
-				     xfer->dir);*/
+			pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents,
+				     xfer->dir);
 			sgt->nents = 0;
 		}
 	}


### PR DESCRIPTION
If anyone gets strange kernel messages like:
Mar 16 15:49:01 silverlight-host-4-zrh kernel: #PF: supervisor read access in kernel mode Mar 16 15:49:01 silverlight-host-4-zrh kernel: #PF: error_code(0x0000) - not-present page Mar 16 15:49:01 silverlight-host-4-zrh kernel: PGD 0 P4D 0 Mar 16 15:49:01 silverlight-host-4-zrh kernel: Oops: 0000 [#3] PREEMPT SMP NOPTI

then maybe still revert this. it may be an acceidental 'makes it work'